### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Configure `gsoci.azurecr.io` as the default container image registry.
 - Abstract managementcluster (refactoring).
 
 ## [0.3.0] - 2023-11-22

--- a/helm/object-storage-operator/values.yaml
+++ b/helm/object-storage-operator/values.yaml
@@ -3,7 +3,7 @@ global:
     enforced: false
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   repository: "giantswarm/object-storage-operator"
   tag: ""
 


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
