### PR TITLE
sanitize azure bucket tag keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add basic tag key sanitization for azure bucket tags as they need to match c# identifiers.
+
 ## [0.5.4] - 2024-04-08
 
 ### Fixed

--- a/internal/pkg/service/objectstorage/cloud/azure/storage.go
+++ b/internal/pkg/service/objectstorage/cloud/azure/storage.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -321,6 +322,10 @@ func (s AzureObjectStorageAdapter) setLifecycleRules(ctx context.Context, bucket
 	return err
 }
 
+func sanitizeTagKey(tagName string) string {
+	return strings.ReplaceAll(tagName, "-", "_")
+}
+
 // setTags set cluster additionalTags and bucket tags into Storage Container Metadata
 func (s AzureObjectStorageAdapter) setTags(ctx context.Context, bucket *v1alpha1.Bucket) error {
 	storageAccountName := s.getStorageAccountName(bucket.Spec.Name)
@@ -329,7 +334,7 @@ func (s AzureObjectStorageAdapter) setTags(ctx context.Context, bucket *v1alpha1
 		// We use this to avoid pointer issues in range loops.
 		tag := t
 		if tag.Key != "" && tag.Value != "" {
-			tags[tag.Key] = &tag.Value
+			tags[sanitizeTagKey(tag.Key)] = &tag.Value
 		}
 	}
 	for k, v := range s.cluster.GetTags() {
@@ -337,7 +342,7 @@ func (s AzureObjectStorageAdapter) setTags(ctx context.Context, bucket *v1alpha1
 		key := k
 		value := v
 		if key != "" && value != "" {
-			tags[key] = &value
+			tags[sanitizeTagKey(key)] = &value
 		}
 	}
 


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds tag sanitization for Azure tags to fix https://github.com/giantswarm/giantswarm/issues/30664

The issue happening on glippy right now is related to the kaas generated cluster tags (c.f. explanation https://github.com/giantswarm/giantswarm/issues/30664#issuecomment-2099087777)

In theory, the tags should be valid c# identifiers, but in practice, the sanitization fixes only the existing issue, which is that some tag keys use `hyphens` which is not valid so we replace it with an `underscore` instead.

### Checklist

- [x] Update changelog in CHANGELOG.md.
