### PR TITLE
Add support for the region of China

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add support for the region of China.
+
 ## [0.5.5] - 2024-05-13
 
 ### Fixed

--- a/internal/pkg/service/objectstorage/cloud/aws/s3.go
+++ b/internal/pkg/service/objectstorage/cloud/aws/s3.go
@@ -120,7 +120,10 @@ func (s S3ObjectStorageAdapter) setLifecycleRules(ctx context.Context, bucket *v
 
 func (s S3ObjectStorageAdapter) setBucketPolicy(ctx context.Context, bucket *v1alpha1.Bucket) error {
 	var policy bytes.Buffer
-	err := s.bucketPolicyTemplate.Execute(&policy, BucketPolicyData{bucket.Spec.Name})
+	err := s.bucketPolicyTemplate.Execute(&policy, BucketPolicyData{
+		AWSDomain:  awsDomain(s.cluster.Region),
+		BucketName: bucket.Spec.Name,
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/31052

### What this PR does / why we need it

This PR add support for the region of China by being able to switch the templated aws domain in aws resources if the operator is deployed in a Chinese region.

### Checklist

- [x] Update changelog in CHANGELOG.md.
