### PR TITLE
Change azure storage account secret name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change azure storage account secret name by using the bucket name instead of the storage account name to not be bothered by azure storage account name limitations (up to 24 characters) which truncates secret name for long bucket names like `giantswarm-glippy-mimir-ruler` which becomes `giantswarmglippymimirrul`. As this rule is unpredictable (depends on the installation name), it is better to fix the name of the secret.
+
 ## [0.6.1] - 2024-06-17
 
 ### Fixed
 
-- Fix object-storage-operator templating.
+- Fix object-storage-operator aws templating by using the root scope when possible.
 
 ## [0.6.0] - 2024-06-17
 

--- a/internal/pkg/service/objectstorage/cloud/azure/storage.go
+++ b/internal/pkg/service/objectstorage/cloud/azure/storage.go
@@ -168,7 +168,7 @@ func (s AzureObjectStorageAdapter) CreateBucket(ctx context.Context, bucket *v1a
 		nil,
 	)
 	if err != nil {
-		return fmt.Errorf("Impossible to retrieve Access Keys from Storage Account %s", storageAccountName)
+		return fmt.Errorf("unable to retrieve access keys from storage account %s", storageAccountName)
 	}
 	// Then, we retrieve the Access Key for 'key1'
 	foundKey1 := false
@@ -178,7 +178,7 @@ func (s AzureObjectStorageAdapter) CreateBucket(ctx context.Context, bucket *v1a
 			// Finally, we create the Secret into the bucket namespace
 			secret := &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      storageAccountName,
+					Name:      bucket.Spec.Name,
 					Namespace: bucket.Namespace,
 					Labels: map[string]string{
 						"giantswarm.io/managed-by": "object-storage-operator",
@@ -193,12 +193,12 @@ func (s AzureObjectStorageAdapter) CreateBucket(ctx context.Context, bucket *v1a
 			if err != nil {
 				return err
 			}
-			s.logger.Info(fmt.Sprintf("Secret %s created", storageAccountName))
+			s.logger.Info(fmt.Sprintf("created secret %s", bucket.Spec.Name))
 			break
 		}
 	}
 	if !foundKey1 {
-		return fmt.Errorf("Impossible to retrieve Access Keys 'key1' from Storage Account %s", storageAccountName)
+		return fmt.Errorf("unable to retrieve access keys 'key1' from storage account %s", storageAccountName)
 	}
 
 	return nil
@@ -227,20 +227,20 @@ func (s AzureObjectStorageAdapter) DeleteBucket(ctx context.Context, bucket *v1a
 	err = s.client.Get(
 		ctx,
 		types.NamespacedName{
+			Name:      bucket.Spec.Name,
 			Namespace: bucket.Namespace,
-			Name:      storageAccountName,
 		},
 		&secret)
 	if err != nil {
-		s.logger.Error(err, fmt.Sprintf("Impossible to retrieve Secret %s", storageAccountName))
+		s.logger.Error(err, fmt.Sprintf("unable to retrieve secret %s", bucket.Spec.Name))
 		return err
 	}
 	err = s.client.Delete(ctx, &secret)
 	if err != nil {
-		s.logger.Error(err, fmt.Sprintf("Impossible to delete Secret %s", storageAccountName))
+		s.logger.Error(err, fmt.Sprintf("unable to delete secret %s", bucket.Spec.Name))
 		return err
 	}
-	s.logger.Info(fmt.Sprintf("Secret %s deleted", storageAccountName))
+	s.logger.Info(fmt.Sprintf("deleted secret %s", bucket.Spec.Name))
 
 	return nil
 }


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/3334 and https://github.com/giantswarm/giantswarm/issues/31087

This PR changes the geneated azure storage account secret name by using the bucket name instead of the storage account name to not be bothered by azure storage account name limitations (up to 24 characters) which truncates secret name for long bucket names like `giantswarm-glippy-mimir-ruler` which becomes `giantswarmglippymimirrul`. As this rule is unpredictable (depends on the installation name), it is better to fix the name of the secret.

As the secret is only created when we create the storage account, releasing this will require us to duplicate existing secrets with the old and new name, update the loki and mimir config and then delete the old secrets

### Checklist

- [x] Update changelog in CHANGELOG.md.
