### PR TITLE
Add custom metrics counting the number of Bucket CR delete reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add custom metrics counting the number of Bucket CR delete reconciliation.
+
 ## [0.7.0] - 2024-06-18
 
 ### Changed

--- a/internal/pkg/flags/metrics.go
+++ b/internal/pkg/flags/metrics.go
@@ -1,0 +1,17 @@
+package flags
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	ReconcileDeleteGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "bucket_reconcile_delete_total",
+			Help: "Number of reconcile delete events for a bucket CR.",
+		},
+		[]string{"bucket_name"},
+	)
+)
+
+func RegisterGauge() {
+	prometheus.MustRegister(ReconcileDeleteGauge)
+}

--- a/main.go
+++ b/main.go
@@ -105,6 +105,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Initialization of the custom gauge to count the number of reconcileDelete bucket events
+	flags.RegisterGauge()
+
 	var objectStorage objectstorage.ObjectStorageServiceFactory
 	var clusterGetter cluster.ClusterGetter
 	switch managementCluster.Provider {


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/31006

This PR: 

Add a custom metrics (gauge) counting the number of Bucket CR delete reconciliation in order to make an alert based on it. 
That alert will tell Atlas that an installation wants  to delete a bucket.
An opsrecipe will explain what to do in a such alert: either nothing because we want to keep data or different manual steps to clean properly the bucket.


### What this PR does / why we need it


### Checklist

- [x] Update changelog in CHANGELOG.md.
