### PR TITLE
Manage bucket deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ReclaimPolicy added in the Bucket CR to manage the data clean up (retain or delete).
+- Add a finalizer on the Azure secret to prevent its deletion.
+- Empty all the objects in the S3 bucket in case of bucket deletion.
+
 ## [0.7.0] - 2024-06-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ We add a lifecyle management rule on the storage account to clean old data (`buc
 
 When the object storage is created, we retrieve the Access Key and create a secret in the bucket namespace containing the name of the storage account and the access key. This secret is necessary for the application desiring to use this object storage.
 
+By default, a reclaim policy is set to `reclaimPolicy: Retain` that means when a Bucket CR is deleted, nothing is done. The idea is to avoid accidental Bucket CR deletions that result in data loss on the Cloud provider.
+However, if we need to clean up the bucket, we can set the reclaim policy to `reclaimPolicy: Delete`. This will remove all data on the Cloud provider.
+
 # Testing
 
 You can run all tests with

--- a/api/v1alpha1/bucket_types.go
+++ b/api/v1alpha1/bucket_types.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	BucketFinalizer     = "bucket.objectstorage.giantswarm.io"
-	ReclaimPolicyRetain = "Retain"
-	ReclaimPolicyDelete = "Delete"
+	BucketFinalizer      = "bucket.objectstorage.giantswarm.io"
+	AzureSecretFinalizer = "giantswarm.io/object-storage-operator"
+	ReclaimPolicyRetain  = "Retain"
+	ReclaimPolicyDelete  = "Delete"
 )
 
 // BucketSpec defines the desired state of Bucket

--- a/api/v1alpha1/bucket_types.go
+++ b/api/v1alpha1/bucket_types.go
@@ -21,7 +21,9 @@ import (
 )
 
 const (
-	BucketFinalizer = "bucket.objectstorage.giantswarm.io"
+	BucketFinalizer     = "bucket.objectstorage.giantswarm.io"
+	ReclaimPolicyRetain = "Retain"
+	ReclaimPolicyDelete = "Delete"
 )
 
 // BucketSpec defines the desired state of Bucket
@@ -32,6 +34,10 @@ type BucketSpec struct {
 	// Expiration policy on the objects in the bucket.
 	// +optional
 	ExpirationPolicy *BucketExpirationPolicy `json:"expirationPolicy,omitempty"`
+
+	// Reclaim policy on the bucket.
+	// +optional
+	ReclaimPolicy string `json:"reclaimPolicy,omitempty"`
 
 	// Access role that can be assumed to access the bucket
 	AccessRole *BucketAccessRole `json:"accessRole,omitempty"`

--- a/api/v1alpha1/bucket_types.go
+++ b/api/v1alpha1/bucket_types.go
@@ -21,10 +21,11 @@ import (
 )
 
 const (
-	BucketFinalizer     = "bucket.objectstorage.giantswarm.io"
-	AzureSecFinalizer   = "giantswarm.io/object-storage-operator"
-	ReclaimPolicyRetain = "Retain"
-	ReclaimPolicyDelete = "Delete"
+	BucketFinalizer = "bucket.objectstorage.giantswarm.io"
+	// Secret finalizer need a "/" in the name https://github.com/kubernetes/kubernetes/blob/36981002246682ed7dc4de54ccc2a96c1a0cbbdb/pkg/apis/core/validation/validation.go#L5314-L5320
+	AzureSecretFinalizer = "giantswarm.io/secret.object-storage-operator" // #nosec G101
+	ReclaimPolicyRetain  = "Retain"
+	ReclaimPolicyDelete  = "Delete"
 )
 
 // BucketSpec defines the desired state of Bucket

--- a/api/v1alpha1/bucket_types.go
+++ b/api/v1alpha1/bucket_types.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	BucketFinalizer      = "bucket.objectstorage.giantswarm.io"
-	AzureSecretFinalizer = "giantswarm.io/object-storage-operator"
-	ReclaimPolicyRetain  = "Retain"
-	ReclaimPolicyDelete  = "Delete"
+	BucketFinalizer     = "bucket.objectstorage.giantswarm.io"
+	AzureSecFinalizer   = "giantswarm.io/object-storage-operator"
+	ReclaimPolicyRetain = "Retain"
+	ReclaimPolicyDelete = "Delete"
 )
 
 // BucketSpec defines the desired state of Bucket

--- a/api/v1alpha1/bucket_types.go
+++ b/api/v1alpha1/bucket_types.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	BucketFinalizer = "bucket.objectstorage.giantswarm.io"
-	// Secret finalizer need a "/" in the name https://github.com/kubernetes/kubernetes/blob/36981002246682ed7dc4de54ccc2a96c1a0cbbdb/pkg/apis/core/validation/validation.go#L5314-L5320
-	AzureSecretFinalizer = "giantswarm.io/secret.object-storage-operator" // #nosec G101
+	// Finalizer needs to follow the format "domain name, a forward slash and the name of the finalizer"
+	// See https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#finalizers
+	BucketFinalizer      = "objectstorage.giantswarm.io/bucket"
+	AzureSecretFinalizer = "objectstorage.giantswarm.io/secret" // #nosec G101
 	ReclaimPolicyRetain  = "Retain"
 	ReclaimPolicyDelete  = "Delete"
 )

--- a/config/crd/objectstorage.giantswarm.io_buckets.yaml
+++ b/config/crd/objectstorage.giantswarm.io_buckets.yaml
@@ -72,6 +72,9 @@ spec:
               name:
                 description: Name is the name of the bucket to create.
                 type: string
+              reclaimPolicy:
+                description: Reclaim policy on the bucket.
+                type: string
               tags:
                 description: Tags to add to the bucket.
                 items:

--- a/config/samples/objectstorage_v1alpha1_bucket.yaml
+++ b/config/samples/objectstorage_v1alpha1_bucket.yaml
@@ -12,6 +12,7 @@ spec:
   name: gs-test-object-storage-operator
   expirationPolicy:
     days: 30
+  reclaimPolicy: Retain
   tags:
   - key: installation
     value: golem

--- a/helm/object-storage-operator/templates/rbac.yaml
+++ b/helm/object-storage-operator/templates/rbac.yaml
@@ -94,6 +94,7 @@ rules:
     verbs:
       - create
       - update
+      - patch
       - delete
       - get
       - list

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -149,7 +149,7 @@ func (r BucketReconciler) reconcileDelete(ctx context.Context, objectStorageServ
 
 	logger.Info("Checking if bucket exists")
 	exists, err := objectStorageService.ExistsBucket(ctx, bucket)
-	if err != nil && exists {
+	if err == nil && exists {
 		switch bucket.Spec.ReclaimPolicy {
 		case v1alpha1.ReclaimPolicyDelete:
 			logger.Info("Reclaim policy is set to delete, deleting bucket")

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -169,6 +169,8 @@ func (r BucketReconciler) reconcileDelete(ctx context.Context, objectStorageServ
 					return errors.WithStack(err)
 				}
 				logger.Info("Bucket access role deleted")
+			} else {
+				logger.Info("Bucket access role not found, skipping deletion")
 			}
 		case v1alpha1.ReclaimPolicyRetain:
 			logger.Info("Reclaim policy is set to retain, not deleting bucket")
@@ -177,7 +179,7 @@ func (r BucketReconciler) reconcileDelete(ctx context.Context, objectStorageServ
 		}
 	}
 
-	// Bucket is deleted so remove the finalizer.
+	// Remove the finalizer.
 	originalBucket := bucket.DeepCopy()
 	controllerutil.RemoveFinalizer(bucket, v1alpha1.BucketFinalizer)
 	return r.Client.Patch(ctx, bucket, client.MergeFrom(originalBucket))

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -172,17 +172,18 @@ func (r BucketReconciler) reconcileDelete(ctx context.Context, objectStorageServ
 			} else {
 				logger.Info("Bucket access role not found, skipping deletion")
 			}
+
+			// Remove the finalizer.
+			originalBucket := bucket.DeepCopy()
+			controllerutil.RemoveFinalizer(bucket, v1alpha1.BucketFinalizer)
+			return r.Client.Patch(ctx, bucket, client.MergeFrom(originalBucket))
 		case v1alpha1.ReclaimPolicyRetain:
 			logger.Info("Reclaim policy is set to retain, not deleting bucket")
 		default:
 			logger.Info("Reclaim policy is the default one (retain), not deleting bucket")
 		}
 	}
-
-	// Remove the finalizer.
-	originalBucket := bucket.DeepCopy()
-	controllerutil.RemoveFinalizer(bucket, v1alpha1.BucketFinalizer)
-	return r.Client.Patch(ctx, bucket, client.MergeFrom(originalBucket))
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/bucket_controller.go
+++ b/internal/controller/bucket_controller.go
@@ -149,37 +149,32 @@ func (r BucketReconciler) reconcileDelete(ctx context.Context, objectStorageServ
 
 	logger.Info("Checking if bucket exists")
 	exists, err := objectStorageService.ExistsBucket(ctx, bucket)
-	if err != nil {
-		return errors.WithStack(err)
-	} else if !exists {
-		logger.Info("Bucket does not exist")
-		return nil
-	}
+	if err != nil && exists {
+		switch bucket.Spec.ReclaimPolicy {
+		case v1alpha1.ReclaimPolicyDelete:
+			logger.Info("Reclaim policy is set to delete, deleting bucket")
 
-	switch bucket.Spec.ReclaimPolicy {
-	case v1alpha1.ReclaimPolicyDelete:
-		logger.Info("Reclaim policy is set to delete, deleting bucket")
-
-		logger.Info("Bucket exists, deleting")
-		err = objectStorageService.DeleteBucket(ctx, bucket)
-		if err != nil {
-			logger.Error(err, "Bucket could not be deleted")
-			return errors.WithStack(err)
-		}
-		logger.Info("Bucket deleted")
-
-		if bucket.Spec.AccessRole != nil && bucket.Spec.AccessRole.RoleName != "" {
-			logger.Info("Deleting bucket access role")
-			err = accessRoleService.DeleteRole(ctx, bucket)
+			logger.Info("Bucket exists, deleting")
+			err = objectStorageService.DeleteBucket(ctx, bucket)
 			if err != nil {
+				logger.Error(err, "Bucket could not be deleted")
 				return errors.WithStack(err)
 			}
-			logger.Info("Bucket access role deleted")
+			logger.Info("Bucket deleted")
+
+			if bucket.Spec.AccessRole != nil && bucket.Spec.AccessRole.RoleName != "" {
+				logger.Info("Deleting bucket access role")
+				err = accessRoleService.DeleteRole(ctx, bucket)
+				if err != nil {
+					return errors.WithStack(err)
+				}
+				logger.Info("Bucket access role deleted")
+			}
+		case v1alpha1.ReclaimPolicyRetain:
+			logger.Info("Reclaim policy is set to retain, not deleting bucket")
+		default:
+			logger.Info("Reclaim policy is the default one (retain), not deleting bucket")
 		}
-	case v1alpha1.ReclaimPolicyRetain:
-		logger.Info("Reclaim policy is set to retain, not deleting bucket")
-	default:
-		logger.Info("Reclaim policy is the default one (retain), not deleting bucket")
 	}
 
 	// Bucket is deleted so remove the finalizer.

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -382,7 +382,8 @@ var _ = Describe("Bucket Reconciler", func() {
 							},
 						},
 						Spec: v1alpha1.BucketSpec{
-							Name: BucketName,
+							Name:          BucketName,
+							ReclaimPolicy: v1alpha1.ReclaimPolicyDelete,
 						},
 						Status: v1alpha1.BucketStatus{},
 					}
@@ -774,7 +775,8 @@ var _ = Describe("Bucket Reconciler", func() {
 							},
 						},
 						Spec: v1alpha1.BucketSpec{
-							Name: BucketName,
+							Name:          BucketName,
+							ReclaimPolicy: v1alpha1.ReclaimPolicyDelete,
 						},
 						Status: v1alpha1.BucketStatus{},
 					}

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -419,7 +419,7 @@ var _ = Describe("Bucket Reconciler", func() {
 						Expect(objectStorageService.DeleteBucketCallCount()).To(Equal(0))
 						var existingBucket v1alpha1.Bucket
 						_ = fakeClient.Get(ctx, bucketKey, &existingBucket)
-						Expect(existingBucket.Finalizers).To(ContainElement(v1alpha1.BucketFinalizer))
+						Expect(existingBucket.Finalizers).ToNot(ContainElement(v1alpha1.BucketFinalizer))
 					})
 				})
 
@@ -470,7 +470,7 @@ var _ = Describe("Bucket Reconciler", func() {
 						Expect(objectStorageService.DeleteBucketCallCount()).To(Equal(0))
 						var existingBucket v1alpha1.Bucket
 						_ = fakeClient.Get(ctx, bucketKey, &existingBucket)
-						Expect(existingBucket.Finalizers).To(ContainElement(v1alpha1.BucketFinalizer))
+						Expect(existingBucket.Finalizers).ToNot(ContainElement(v1alpha1.BucketFinalizer))
 					})
 				})
 
@@ -864,7 +864,7 @@ var _ = Describe("Bucket Reconciler", func() {
 						Expect(objectStorageService.DeleteBucketCallCount()).To(Equal(0))
 						var existingBucket v1alpha1.Bucket
 						_ = fakeClient.Get(ctx, bucketKey, &existingBucket)
-						Expect(existingBucket.Finalizers).To(ContainElement(v1alpha1.BucketFinalizer))
+						Expect(existingBucket.Finalizers).ToNot(ContainElement(v1alpha1.BucketFinalizer))
 					})
 				})
 

--- a/internal/controller/bucket_controller_test.go
+++ b/internal/controller/bucket_controller_test.go
@@ -419,7 +419,7 @@ var _ = Describe("Bucket Reconciler", func() {
 						Expect(objectStorageService.DeleteBucketCallCount()).To(Equal(0))
 						var existingBucket v1alpha1.Bucket
 						_ = fakeClient.Get(ctx, bucketKey, &existingBucket)
-						Expect(existingBucket.Finalizers).ToNot(ContainElement(v1alpha1.BucketFinalizer))
+						Expect(existingBucket.Finalizers).To(ContainElement(v1alpha1.BucketFinalizer))
 					})
 				})
 
@@ -470,7 +470,7 @@ var _ = Describe("Bucket Reconciler", func() {
 						Expect(objectStorageService.DeleteBucketCallCount()).To(Equal(0))
 						var existingBucket v1alpha1.Bucket
 						_ = fakeClient.Get(ctx, bucketKey, &existingBucket)
-						Expect(existingBucket.Finalizers).ToNot(ContainElement(v1alpha1.BucketFinalizer))
+						Expect(existingBucket.Finalizers).To(ContainElement(v1alpha1.BucketFinalizer))
 					})
 				})
 
@@ -484,7 +484,7 @@ var _ = Describe("Bucket Reconciler", func() {
 						Expect(objectStorageService.DeleteBucketCallCount()).To(Equal(0))
 						var existingBucket v1alpha1.Bucket
 						_ = fakeClient.Get(ctx, bucketKey, &existingBucket)
-						Expect(existingBucket.Finalizers).ToNot(ContainElement(v1alpha1.BucketFinalizer))
+						Expect(existingBucket.Finalizers).To(ContainElement(v1alpha1.BucketFinalizer))
 					})
 				})
 			})
@@ -864,7 +864,7 @@ var _ = Describe("Bucket Reconciler", func() {
 						Expect(objectStorageService.DeleteBucketCallCount()).To(Equal(0))
 						var existingBucket v1alpha1.Bucket
 						_ = fakeClient.Get(ctx, bucketKey, &existingBucket)
-						Expect(existingBucket.Finalizers).ToNot(ContainElement(v1alpha1.BucketFinalizer))
+						Expect(existingBucket.Finalizers).To(ContainElement(v1alpha1.BucketFinalizer))
 					})
 				})
 

--- a/internal/pkg/service/objectstorage/cloud/aws/s3.go
+++ b/internal/pkg/service/objectstorage/cloud/aws/s3.go
@@ -83,14 +83,17 @@ func (s S3ObjectStorageAdapter) DeleteBucket(ctx context.Context, bucket *v1alph
 			})
 		}
 
-		_, err = s.s3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
-			Bucket: aws.String(bucket.Spec.Name),
-			Delete: &types.Delete{
-				Objects: objects,
-			},
-		})
-		if err != nil {
-			return err
+		if len(objects) != 0 {
+			_, err = s.s3Client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+				Bucket: aws.String(bucket.Spec.Name),
+				Delete: &types.Delete{
+					Objects: objects,
+				},
+			})
+			if err != nil {
+				return err
+
+			}
 		}
 	}
 

--- a/internal/pkg/service/objectstorage/cloud/azure/storage.go
+++ b/internal/pkg/service/objectstorage/cloud/azure/storage.go
@@ -183,6 +183,9 @@ func (s AzureObjectStorageAdapter) CreateBucket(ctx context.Context, bucket *v1a
 					Labels: map[string]string{
 						"giantswarm.io/managed-by": "object-storage-operator",
 					},
+					Finalizers: []string{
+						v1alpha1.BucketFinalizer,
+					},
 				},
 				Data: map[string][]byte{
 					"accountName": []byte(storageAccountName),

--- a/internal/pkg/service/objectstorage/cloud/azure/storage.go
+++ b/internal/pkg/service/objectstorage/cloud/azure/storage.go
@@ -185,7 +185,7 @@ func (s AzureObjectStorageAdapter) CreateBucket(ctx context.Context, bucket *v1a
 						"giantswarm.io/managed-by": "object-storage-operator",
 					},
 					Finalizers: []string{
-						v1alpha1.BucketFinalizer,
+						v1alpha1.AzureSecretFinalizer,
 					},
 				},
 				Data: map[string][]byte{
@@ -241,7 +241,7 @@ func (s AzureObjectStorageAdapter) DeleteBucket(ctx context.Context, bucket *v1a
 	}
 	// We remove the finalizer to allow the secret to be deleted
 	originalSecret := secret.DeepCopy()
-	controllerutil.RemoveFinalizer(&secret, v1alpha1.BucketFinalizer)
+	controllerutil.RemoveFinalizer(&secret, v1alpha1.AzureSecretFinalizer)
 	err = s.client.Patch(ctx, &secret, client.MergeFrom(originalSecret))
 	if err != nil {
 		s.logger.Error(err, fmt.Sprintf("unable to remove the finalizer in the secret %s", bucket.Spec.Name))

--- a/internal/pkg/service/objectstorage/cloud/azure/storage.go
+++ b/internal/pkg/service/objectstorage/cloud/azure/storage.go
@@ -185,7 +185,7 @@ func (s AzureObjectStorageAdapter) CreateBucket(ctx context.Context, bucket *v1a
 						"giantswarm.io/managed-by": "object-storage-operator",
 					},
 					Finalizers: []string{
-						v1alpha1.AzureSecFinalizer,
+						v1alpha1.AzureSecretFinalizer,
 					},
 				},
 				Data: map[string][]byte{
@@ -241,7 +241,7 @@ func (s AzureObjectStorageAdapter) DeleteBucket(ctx context.Context, bucket *v1a
 	}
 	// We remove the finalizer to allow the secret to be deleted
 	originalSecret := secret.DeepCopy()
-	controllerutil.RemoveFinalizer(&secret, v1alpha1.AzureSecFinalizer)
+	controllerutil.RemoveFinalizer(&secret, v1alpha1.AzureSecretFinalizer)
 	err = s.client.Patch(ctx, &secret, client.MergeFrom(originalSecret))
 	if err != nil {
 		s.logger.Error(err, fmt.Sprintf("unable to remove the finalizer in the secret %s", bucket.Spec.Name))

--- a/internal/pkg/service/objectstorage/cloud/azure/storage.go
+++ b/internal/pkg/service/objectstorage/cloud/azure/storage.go
@@ -185,7 +185,7 @@ func (s AzureObjectStorageAdapter) CreateBucket(ctx context.Context, bucket *v1a
 						"giantswarm.io/managed-by": "object-storage-operator",
 					},
 					Finalizers: []string{
-						v1alpha1.AzureSecretFinalizer,
+						v1alpha1.AzureSecFinalizer,
 					},
 				},
 				Data: map[string][]byte{
@@ -241,7 +241,7 @@ func (s AzureObjectStorageAdapter) DeleteBucket(ctx context.Context, bucket *v1a
 	}
 	// We remove the finalizer to allow the secret to be deleted
 	originalSecret := secret.DeepCopy()
-	controllerutil.RemoveFinalizer(&secret, v1alpha1.AzureSecretFinalizer)
+	controllerutil.RemoveFinalizer(&secret, v1alpha1.AzureSecFinalizer)
 	err = s.client.Patch(ctx, &secret, client.MergeFrom(originalSecret))
 	if err != nil {
 		s.logger.Error(err, fmt.Sprintf("unable to remove the finalizer in the secret %s", bucket.Spec.Name))


### PR DESCRIPTION
### What this PR does / why we need it
towards https://github.com/giantswarm/giantswarm/issues/31006

That PR implements:
- ReclaimPolicy added in the Bucket CR to manage the data clean up (retain or delete).
- Add a finalizer on the Azure secret to prevent its deletion.
- Empty all the objects in the S3 bucket in case of bucket deletion.

### How to validate

Go to a CAPZ test MC `glean`
1. Create a bucket (by default, the ReclaimPolicy should be Retain)
2. Delete the Bucket CR
3. Check object-storage-operator logs
4. Check the Bucket CR is still there
5. Check the data are still there on Azure
6. Try to delete the Azure secret and check you can't delete it
7. Edit the Bucket CR and set `ReclaimPolicy: Delete`
8. Delete the Bucket CR
9. Check object-storage-operator logs
10. Check the Bucket CR is removed
11. Check the data are removed on Azure
12. Check the Azure secret is removed

Go to a CAPA test MC `golem`
1. Create a bucket (by default, the ReclaimPolicy should be Retain)
2. Delete the Bucket CR
3. Check object-storage-operator logs
4. Check the Bucket CR is still there
5. Check the data are still there on AWS
7. Edit the Bucket CR and set `ReclaimPolicy: Delete`
8. Delete the Bucket CR
9. Check object-storage-operator logs
10. Check the Bucket CR is removed
11. Check the data are removed on AWS

### Checklist

- [x] Update changelog in CHANGELOG.md.
