### PR TITLE
fix bucket creation in us east 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix bucket creation in us-east-1.
+
 ## [0.10.0] - 2025-01-07
 
 ### Changed


### PR DESCRIPTION
### What this PR does / why we need it

Buckets are not created on finch because us-east-1 is a special snowflakes that needs to have a location constraint set to null or it will fail https://github.com/aws/aws-sdk-go-v2/issues/1894

### Checklist

- [x] Update changelog in CHANGELOG.md.
