### PR TITLE
fix us-east-1 xml output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix xml output for us-east-1 region as the bucket creation config needs to be empty.
+
 ## [0.10.1] - 2025-02-06
 
 ### Fixed

--- a/internal/pkg/service/objectstorage/cloud/aws/s3.go
+++ b/internal/pkg/service/objectstorage/cloud/aws/s3.go
@@ -55,17 +55,18 @@ func (s S3ObjectStorageAdapter) ExistsBucket(ctx context.Context, bucket *v1alph
 }
 
 func (s S3ObjectStorageAdapter) CreateBucket(ctx context.Context, bucket *v1alpha1.Bucket) error {
-	createBucketConfiguration := types.CreateBucketConfiguration{}
+	createBucketInput := s3.CreateBucketInput{
+		Bucket: aws.String(bucket.Spec.Name),
+	}
 	// If the region is us-east-1, then location needs to be null, FFS
 	// https://github.com/aws/aws-sdk-go-v2/issues/1894
 	if s.cluster.GetRegion() != "us-east-1" {
-		createBucketConfiguration.LocationConstraint = types.BucketLocationConstraint(s.cluster.GetRegion())
+		createBucketInput.CreateBucketConfiguration = &types.CreateBucketConfiguration{
+			LocationConstraint: types.BucketLocationConstraint(s.cluster.GetRegion()),
+		}
 	}
 
-	_, err := s.s3Client.CreateBucket(ctx, &s3.CreateBucketInput{
-		Bucket:                    aws.String(bucket.Spec.Name),
-		CreateBucketConfiguration: &createBucketConfiguration,
-	})
+	_, err := s.s3Client.CreateBucket(ctx, &createBucketInput)
 	return err
 }
 


### PR DESCRIPTION
### What this PR does / why we need it

So it looks like setting an empty CreateBucketConfiguration in the api XML requests is invalid ... 

### Checklist

- [x] Update changelog in CHANGELOG.md.
