### PR TITLE
Azure: read clusteridentity's namespace from cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Azure: read ClusterIdentity's namespace from Cluster resource
+
 ## [0.10.4] - 2025-04-23
 
 ### Fixed

--- a/internal/pkg/service/objectstorage/cloud/azure/cluster.go
+++ b/internal/pkg/service/objectstorage/cloud/azure/cluster.go
@@ -118,6 +118,15 @@ func (c AzureClusterGetter) GetCluster(ctx context.Context) (cluster.Cluster, er
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
+	case "WorkloadIdentity":
+		tenantID, found, err = unstructured.NestedString(clusterIdentity.Object, "spec", "tenantID")
+		if !found || err != nil {
+			return nil, errors.New("Missing or incorrect identity.tenantID")
+		}
+		clientID, found, err = unstructured.NestedString(clusterIdentity.Object, "spec", "clientID")
+		if !found || err != nil {
+			return nil, errors.New("Missing or incorrect identity.clientID")
+		}
 	default:
 		return nil, errors.Errorf("Unsupported TypeIdentity %s", typeIdentity)
 	}

--- a/internal/pkg/service/objectstorage/cloud/azure/service.go
+++ b/internal/pkg/service/objectstorage/cloud/azure/service.go
@@ -49,6 +49,14 @@ func (s AzureObjectStorageService) NewObjectStorageService(ctx context.Context, 
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
+	case "WorkloadIdentity":
+		cred, err = azidentity.NewWorkloadIdentityCredential(&azidentity.WorkloadIdentityCredentialOptions{
+			TenantID: azureCredentials.TenantID,
+			ClientID: azureCredentials.ClientID,
+		})
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
 	default:
 		return nil, errors.New(fmt.Sprintf("Unknown typeIdentity %s", azureCredentials.TypeIdentity))
 	}


### PR DESCRIPTION
### What this PR does / why we need it

We used to consider the ClusterIdentity was always in the same namespace as the cluster.
But it seems it's not always the case.
So let's read the namespace from the cluster, if it's defined.

Towards [#inc-2025-05-02-glean-no-grafana](https://gigantic.slack.com/archives/C08QS1Z6E7M)

### Checklist

- [x] Update changelog in CHANGELOG.md.
